### PR TITLE
Convert waitFor values into arrays

### DIFF
--- a/bq_workers/cloud_build_parser/cloudbuild.yaml
+++ b/bq_workers/cloud_build_parser/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
   args: ['push', 'gcr.io/$PROJECT_ID/cloud-build-worker:${_TAG}']
-  waitFor: build
+  waitFor: ['build']
   id: push
 
 - # Deploy to Cloud Run
@@ -33,7 +33,7 @@ steps:
          '--platform', 'managed'
   ]
   id: deploy
-  waitFor: push
+  waitFor: ['push']
 
 images: [
   'gcr.io/$PROJECT_ID/cloud-build-worker:${_TAG}'

--- a/bq_workers/github_parser/cloudbuild.yaml
+++ b/bq_workers/github_parser/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
   args: ['push', 'gcr.io/$PROJECT_ID/github-worker:${_TAG}']
-  waitFor: build
+  waitFor: ['build']
   id: push
 
 - # Deploy to Cloud Run
@@ -33,7 +33,7 @@ steps:
          '--platform', 'managed'
   ]
   id: deploy
-  waitFor: push
+  waitFor: ['push']
 
 images: [
   'gcr.io/$PROJECT_ID/github-worker:${_TAG}'

--- a/bq_workers/gitlab_parser/cloudbuild.yaml
+++ b/bq_workers/gitlab_parser/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
   args: ['push', 'gcr.io/$PROJECT_ID/gitlab-worker:${_TAG}']
-  waitFor: build
+  waitFor: ['build']
   id: push
 
 - # Deploy to Cloud Run
@@ -33,7 +33,7 @@ steps:
          '--platform', 'managed'
   ]
   id: deploy
-  waitFor: push
+  waitFor: ['push']
 
 images: [
   'gcr.io/$PROJECT_ID/gitlab-worker'

--- a/bq_workers/new_source_template/cloudbuild.yaml
+++ b/bq_workers/new_source_template/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
   args: ['push', 'gcr.io/$PROJECT_ID/${_SOURCE}-worker']
-  waitFor: build
+  waitFor: ['build']
   id: push
 
 - # Deploy to Cloud Run
@@ -33,7 +33,7 @@ steps:
          '--platform', 'managed'
   ]
   id: deploy
-  waitFor: push
+  waitFor: ['push']
 
 images: [
   'gcr.io/$PROJECT_ID/${_SOURCE}-worker'

--- a/bq_workers/tekton_parser/cloudbuild.yaml
+++ b/bq_workers/tekton_parser/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
   args: ['push', 'gcr.io/$PROJECT_ID/tekton-worker']
-  waitFor: build
+  waitFor: ['build']
   id: push
 
 - # Deploy to Cloud Run
@@ -33,7 +33,7 @@ steps:
          '--platform', 'managed'
   ]
   id: deploy
-  waitFor: push
+  waitFor: ['push']
 
 images: [
   'gcr.io/$PROJECT_ID/tekton-worker'

--- a/event_handler/cloudbuild.yaml
+++ b/event_handler/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
 - # Push the container image to Container Registry
   name: gcr.io/cloud-builders/docker
   args: ['push', 'gcr.io/$PROJECT_ID/event-handler:${_TAG}']
-  waitFor: build
+  waitFor: ["build"]
   id: push
 
 - # Deploy to Cloud Run
@@ -34,7 +34,7 @@ steps:
          '--set-env-vars', 'PROJECT_NAME=$PROJECT_ID'
   ]
   id: deploy
-  waitFor: push
+  waitFor: ["push"]
 
 images: [
   'gcr.io/$PROJECT_ID/event-handler:${_TAG}'


### PR DESCRIPTION
### Overview
While trying to use `cloudbuild.yaml` files in GCP Cloud Build Triggers the following error is thrown:

> CloudBuild Trigger: failed unmarshalling build config cloudbuild.yaml: json: cannot unmarshal string into Go value of type []json.RawMessage

The Stack Overflow [answer](https://stackoverflow.com/questions/59233661/cloudbuild-trigger-failed-unmarshalling-build-config-cloudbuild-yaml-json-can) suggest the same as the [documentation](https://cloud.google.com/build/docs/build-config) that the `waitFor` needs to be an array.