### PR TITLE
NAP-275 add busybox image fourkeys

### DIFF
--- a/experimental/terraform/data_parser/main.tf
+++ b/experimental/terraform/data_parser/main.tf
@@ -5,7 +5,7 @@ resource "google_cloud_run_service" "parser" {
   template {
     spec {
       containers {
-        image = "gcr.io/${var.google_project_id}/${var.parser_service_name}-parser"
+        image = "gcr.io/google-containers/busybox"
         env {
           name  = "PROJECT_NAME"
           value = var.google_project_id


### PR DESCRIPTION
Replacing nonexisting container images with busy box image to unblock the terraform build in fourkey project.
