### PR TITLE
use cloudrun placeholder image

### DIFF
--- a/experimental/terraform/data_parser/main.tf
+++ b/experimental/terraform/data_parser/main.tf
@@ -5,7 +5,7 @@ resource "google_cloud_run_service" "parser" {
   template {
     spec {
       containers {
-        image = "gcr.io/google-containers/busybox"
+        image = "gcr.io/cloudrun/placeholder"
         env {
           name  = "PROJECT_NAME"
           value = var.google_project_id

--- a/experimental/terraform/resource_event_handler.tf
+++ b/experimental/terraform/resource_event_handler.tf
@@ -9,7 +9,7 @@ resource "google_cloud_run_service" "event_handler" {
   template {
     spec {
       containers {
-        image = "gcr.io/${var.google_project_id}/event-handler"
+        image = "gcr.io/cloudrun/placeholder"
         env {
           name  = "PROJECT_NAME"
           value = var.google_project_id


### PR DESCRIPTION
NAP-275 fourkeys permissions
use cloudrun placeholder images in data_parser and resource_event_handler

[gcr.io/cloudrun/placeholder](gcr.io/cloudrun/placeholder)