### PR TITLE
Initial cloudbuild webhook notification ideas

### DIFF
--- a/experimental/terraform/cloudbuild-trigger/outputs.tf
+++ b/experimental/terraform/cloudbuild-trigger/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = google_cloudbuild_trigger.continuous_provisioning_trigger.trigger_id
+}
+
+output "name" {
+  value = google_cloudbuild_trigger.continuous_provisioning_trigger.name
+}

--- a/experimental/terraform/cloudbuild-webhook-notification/main.tf
+++ b/experimental/terraform/cloudbuild-webhook-notification/main.tf
@@ -1,0 +1,48 @@
+# notification configuration file generation
+data "template_file" "http_notification" {
+  template = file("${path.module}/templates/http.tpl")
+  vars = {
+    filter = "build.status == Build.Status.SUCCESS && build.substitutions[\"BRANCH_NAME\"] == \"${var.branch}\" && build.build_trigger_id == \"${var.trigger_id}\""
+    url    = var.url
+  }
+}
+# upload notification configuration file to storage bucket
+resource "google_storage_bucket_object" "http_notification" {
+  name    = "configuration/http-notification-for-${var.trigger_name}.yaml"
+  content = data.template_file.http_notification.rendered
+  bucket  = var.storage_bucket.name
+}
+# deploy cloud run notification service
+resource "google_cloud_run_service" "http_notification" {
+  name     = "http-notifier-for-${var.trigger_name}"
+  location = var.google_region
+
+  template {
+    spec {
+      containers {
+        image = "us-east1-docker.pkg.dev/gcb-release/cloud-build-notifiers/http:latest"
+        env {
+          name  = "CONFIG_PATH"
+          value = "${var.storage_bucket.url}/configuration/http-notification-for-${var.trigger_name}.yaml"
+        }
+        env {
+          name  = "PROJECT_ID"
+          value = var.google_project_id
+        }
+      }
+      service_account_name = var.service_account_email
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  autogenerate_revision_name = true
+
+  depends_on = [
+    google_storage_bucket_object.http_notification,
+  ]
+}
+

--- a/experimental/terraform/cloudbuild-webhook-notification/templates/http.tpl
+++ b/experimental/terraform/cloudbuild-webhook-notification/templates/http.tpl
@@ -1,0 +1,10 @@
+apiVersion: cloud-build-notifiers/v1
+kind: HTTPNotifier
+metadata:
+  name: cloudbuild-http-notifier
+spec:
+  notification:
+    filter: ${filter}
+    delivery:
+      # The `http(s)://` protocol prefix is required.
+      url: ${url}

--- a/experimental/terraform/cloudbuild-webhook-notification/variables.tf
+++ b/experimental/terraform/cloudbuild-webhook-notification/variables.tf
@@ -1,0 +1,39 @@
+variable "branch" {
+  description = "The production branch to send deployment notification for."
+  default     = "main"
+  type        = string
+}
+
+variable "google_project_id" {
+  description = "The project id that resources will be deployed too."
+  type        = string
+}
+
+variable "google_region" {
+  description = "(Optional) location region identifier to deploy resources too, see https://cloud.google.com/compute/docs/regions-zones"
+  default     = "us-central1"
+  type        = string
+}
+
+variable "service_account_email" {
+  description = "The service account that is associated with the pubsub messages"
+  type = string
+}
+
+variable "storage_bucket" {
+ description = "Storage bucket resource to upload configurations to."
+}
+
+variable "trigger_id" {
+  description = "The Cloud Build Trigger ID to associate with notification."
+  type        = string
+}
+
+variable "trigger_name" {
+  description = "The Cloud Build Trigger name to associate with notification."
+  type        = string
+}
+
+variable "url" {
+  description = "The event_handler URL to receive notifications"
+}

--- a/experimental/terraform/data_parser/main.tf
+++ b/experimental/terraform/data_parser/main.tf
@@ -71,3 +71,16 @@ module "cloudbuild_for_parser" {
     _FOURKEYS_REGION : var.google_region
   }
 }
+
+module "cloudbuild_notification" {
+  source = "../cloudbuild-webhook-notification"
+
+  branch                = var.cloud_build_branch
+  google_project_id     = var.google_project_id
+  google_region         = var.google_region
+  service_account_email = var.cloud_run_service_account_email
+  trigger_id            = module.cloudbuild_for_parser.id
+  trigger_name          = module.cloudbuild_for_parser.name
+  storage_bucket        = var.storage_bucket
+  url                   = var.notification_url
+}

--- a/experimental/terraform/data_parser/variables.tf
+++ b/experimental/terraform/data_parser/variables.tf
@@ -4,11 +4,16 @@ variable "cloud_build_branch" {
   default = "main"
 }
 
-variable "google_project_id" {
+variable "cloud_run_service_account_email" {
+  description = "The service account that is associated with the pubsub messages"
   type = string
 }
 
 variable "fourkeys_service_account_email" {
+  type = string
+}
+
+variable "google_project_id" {
   type = string
 }
 
@@ -21,6 +26,11 @@ variable "owner" {
   description = "The owner of code repository"
 }
 
+variable "notification_url" {
+  description = "The URL to send cloud build notifications too"
+  type        = string
+}
+
 variable "parser_service_name" {
   type = string
 }
@@ -28,4 +38,8 @@ variable "parser_service_name" {
 variable "repository" {
   type = string
   description = "The name of the git repository"
+}
+
+variable "storage_bucket" {
+ description = "Storage bucket resource to upload configurations to."
 }

--- a/experimental/terraform/reource_storage_bucket.tf
+++ b/experimental/terraform/reource_storage_bucket.tf
@@ -1,0 +1,10 @@
+# create storage bucket for notification configuration file
+module "bucket_for_cloudrun" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "~> 1.3"
+
+  name          = "${var.google_project_id}-${var.google_region}-cloudrun"
+  project_id    = var.google_project_id
+  location      = var.google_region
+  force_destroy = true
+}

--- a/experimental/terraform/resource_parsers.tf
+++ b/experimental/terraform/resource_parsers.tf
@@ -1,14 +1,17 @@
 module "data_parser_service" {
-  for_each                       = toset(var.parsers)
-  source                         = "./data_parser"
+  for_each                        = toset(var.parsers)
+  source                          = "./data_parser"
 
-  cloud_build_branch             = var.cloud_build_branch
-  fourkeys_service_account_email = google_service_account.fourkeys.email
-  google_project_id              = var.google_project_id
-  google_region                  = var.google_region
-  owner                          = var.owner
-  parser_service_name            = each.key
-  repository                     = var.repository
+  cloud_build_branch              = var.cloud_build_branch
+  cloud_run_service_account_email = module.service_account_for_cloudrun.email
+  fourkeys_service_account_email  = google_service_account.fourkeys.email
+  google_project_id               = var.google_project_id
+  google_region                   = var.google_region
+  owner                           = var.owner
+  notification_url                = length(var.mapped_domain) > 0 ? try("https://${var.subdomain}.${var.mapped_domain}", null) : google_cloud_run_service.event_handler.status[0]["url"]
+  parser_service_name             = each.key
+  repository                      = var.repository
+  storage_bucket                  = module.bucket_for_cloudrun.bucket
 
   depends_on = [
     google_project_service.run_api

--- a/experimental/terraform/resource_pubsub.tf
+++ b/experimental/terraform/resource_pubsub.tf
@@ -1,0 +1,43 @@
+data "google_project" "current" {}
+
+# cloud run service account
+# grant clound run invoker permissions
+module "service_account_for_cloudrun" {
+  source     = "terraform-google-modules/service-accounts/google"
+  version    = "~> 3.0"
+  project_id = var.google_project_id
+  names      = ["cloudrun-notifier"]
+  project_roles = [
+    "${var.google_project_id}=>roles/viewer",
+    "${var.google_project_id}=>roles/run.invoker",
+    "${var.google_project_id}=>roles/storage.objectViewer"
+  ]
+}
+# grant project Pub/Sub permissions to create authentication tokens
+module "service_account-iam-bindings" {
+  source = "terraform-google-modules/iam/google//modules/service_accounts_iam"
+
+  service_accounts = module.service_account_for_cloudrun.emails_list
+  project          = var.google_project_id
+  mode             = "additive"
+  bindings = {
+    "roles/iam.serviceAccountTokenCreator" = [
+      "serviceAccount:service-${data.google_project.current.number}@gcp-sa-pubsub.iam.gserviceaccount.com",
+    ]
+  }
+}
+# create the cloud-builds topic
+# create a Pub/Sub push subscriber for cloudbuild http notifier
+module "pubsub" {
+  source  = "terraform-google-modules/pubsub/google"
+  version = "~> 1.8"
+
+  topic      = "cloud-builds" # see https://cloud.google.com/build/docs/configuring-notifications/configure-https for set up and consumption
+  project_id = var.google_project_id
+  pull_subscriptions = [
+    {
+      name            = "pull"
+      service_account = module.service_account_for_cloudrun.email
+    }
+  ]
+}


### PR DESCRIPTION
### Overview
This will add Cloud Build webhook notification as terraform code for `event_handler` and `data_parser`(s).

### Reference
- JIRA: [NAP-314](https://nandosuk.atlassian.net/browse/NAP-314)
- Docs: [Configuring HTTP notifications](https://cloud.google.com/build/docs/configuring-notifications/configure-http)