### PR TITLE
Add name to cloud build http notification template

### DIFF
--- a/experimental/terraform/cloudbuild-webhook-notification/main.tf
+++ b/experimental/terraform/cloudbuild-webhook-notification/main.tf
@@ -3,6 +3,7 @@ data "template_file" "http_notification" {
   template = file("${path.module}/templates/http.tpl")
   vars = {
     filter = "build.status == Build.Status.SUCCESS && build.substitutions[\"BRANCH_NAME\"] == \"${var.branch}\" && build.build_trigger_id == \"${var.trigger_id}\""
+    name   = var.trigger_name
     url    = var.url
   }
 }

--- a/experimental/terraform/cloudbuild-webhook-notification/templates/http.tpl
+++ b/experimental/terraform/cloudbuild-webhook-notification/templates/http.tpl
@@ -1,10 +1,9 @@
 apiVersion: cloud-build-notifiers/v1
 kind: HTTPNotifier
 metadata:
-  name: cloudbuild-http-notifier
+  name: cloudbuild-http-notifier-for-${name}
 spec:
   notification:
     filter: ${filter}
     delivery:
-      # The `http(s)://` protocol prefix is required.
       url: ${url}


### PR DESCRIPTION
### Overview
This will add names to the cloud build http notification template to make them unique.

