### PR TITLE
Pagerduty signature header case was not correct

### DIFF
--- a/event_handler/sources.py
+++ b/event_handler/sources.py
@@ -127,7 +127,7 @@ def get_source(headers):
     if "Argo-CD" in headers.get("User-Agent", ""):
         return "argocd"
 
-    if "X-PagerDuty-Signature" in headers:
+    if "X-Pagerduty-Signature" in headers:
         return "pagerduty"
 
     return headers.get("User-Agent")


### PR DESCRIPTION
Overview:
 Corrected the wrong case used for Pagerduty signature.